### PR TITLE
Verify signature with X509 certificate.

### DIFF
--- a/src/main/java/com/google/webauthn/gaedemo/crypto/Crypto.java
+++ b/src/main/java/com/google/webauthn/gaedemo/crypto/Crypto.java
@@ -17,6 +17,7 @@
 
 package com.google.webauthn.gaedemo.crypto;
 
+import com.google.common.primitives.Bytes;
 import com.google.webauthn.gaedemo.exceptions.WebAuthnException;
 import java.math.BigInteger;
 import java.security.InvalidKeyException;
@@ -27,6 +28,7 @@ import java.security.PublicKey;
 import java.security.Security;
 import java.security.Signature;
 import java.security.SignatureException;
+import java.security.cert.X509Certificate;
 import java.security.spec.InvalidKeySpecException;
 import org.bouncycastle.asn1.sec.SECNamedCurves;
 import org.bouncycastle.asn1.x9.X9ECParameters;
@@ -71,12 +73,19 @@ public class Crypto {
     }
   }
 
+  // TODO add test for this.
+  public static boolean verifySignature(X509Certificate attestationCertificate, byte[] signedBytes, byte[] signature)
+      throws WebAuthnException {
+    return verifySignature(attestationCertificate.getPublicKey(), signedBytes, signature);
+  }
+
   public static PublicKey decodePublicKey(byte[] x, byte[] y) throws WebAuthnException {
     try {
       X9ECParameters curve = SECNamedCurves.getByName("secp256r1");
       ECPoint point;
       try {
-        point = curve.getCurve().createPoint(new BigInteger(x), new BigInteger(y), true);
+        byte[] encodedPublicKey = Bytes.concat(new byte[]{0x04}, x, y);
+        point = curve.getCurve().decodePoint(encodedPublicKey);
       } catch (RuntimeException e) {
         throw new WebAuthnException("Couldn't parse user public key", e);
       }

--- a/src/main/java/com/google/webauthn/gaedemo/objects/AttestationObject.java
+++ b/src/main/java/com/google/webauthn/gaedemo/objects/AttestationObject.java
@@ -56,6 +56,7 @@ public class AttestationObject {
       throws CborException, ResponseException {
     AttestationObject result = new AttestationObject();
     List<DataItem> dataItems = CborDecoder.decode(attestationObject);
+
     if (dataItems.size() == 1 && dataItems.get(0) instanceof Map) {
       DataItem attStmt = null;
       Map attObjMap = (Map) dataItems.get(0);

--- a/src/main/java/com/google/webauthn/gaedemo/objects/AuthenticatorAttestationResponse.java
+++ b/src/main/java/com/google/webauthn/gaedemo/objects/AuthenticatorAttestationResponse.java
@@ -34,7 +34,7 @@ public class AuthenticatorAttestationResponse extends AuthenticatorResponse {
   public AttestationObject decodedObject;
 
   /**
-   * 
+   *
    */
   public AuthenticatorAttestationResponse() {}
 
@@ -53,6 +53,9 @@ public class AuthenticatorAttestationResponse extends AuthenticatorResponse {
       decodedData.appendCodePoint(b);
     }
     System.out.println("Decoded data: " + decodedData.toString());
+
+    // Temporary until fix clientData ordering issue.
+    clientDataString = decodedData.toString();
     clientData = gson.fromJson(decodedData.toString(), CollectedClientData.class);
 
     byte[] attestationObject = BaseEncoding.base64().decode(parsedObject.attestationObject);

--- a/src/main/java/com/google/webauthn/gaedemo/objects/AuthenticatorResponse.java
+++ b/src/main/java/com/google/webauthn/gaedemo/objects/AuthenticatorResponse.java
@@ -17,10 +17,21 @@ package com.google.webauthn.gaedemo.objects;
 public class AuthenticatorResponse {
   protected CollectedClientData clientData;
 
+  // Temporary until fix clientData ordering issue.
+  protected String clientDataString;
+
   /**
    * @return the clientData
    */
   public CollectedClientData getClientData() {
     return clientData;
   }
+
+  /**
+   * @return the clientData string
+   */
+  public String getClientDataString() {
+    return clientDataString;
+  }
+
 }

--- a/src/main/java/com/google/webauthn/gaedemo/objects/FidoU2fAttestationStatement.java
+++ b/src/main/java/com/google/webauthn/gaedemo/objects/FidoU2fAttestationStatement.java
@@ -14,6 +14,7 @@
 
 package com.google.webauthn.gaedemo.objects;
 
+import co.nstant.in.cbor.CborDecoder;
 import co.nstant.in.cbor.CborException;
 import co.nstant.in.cbor.model.Array;
 import co.nstant.in.cbor.model.ByteString;
@@ -53,7 +54,19 @@ public class FidoU2fAttestationStatement extends AttestationStatement {
    */
   public static FidoU2fAttestationStatement decode(DataItem attStmt) {
     FidoU2fAttestationStatement result = new FidoU2fAttestationStatement();
-    Map given = (Map) attStmt;
+    Map given = null;
+
+    if (attStmt instanceof ByteString) {
+      byte[] temp = ((ByteString)attStmt).getBytes();
+      List<DataItem> dataItems = null;
+      try {
+        dataItems = CborDecoder.decode(temp);
+      } catch (Exception e) {}
+      given = (Map) dataItems.get(0);
+    } else {
+      given = (Map) attStmt;
+    }
+
     for (DataItem data : given.getKeys()) {
       if (data instanceof UnicodeString) {
         if (((UnicodeString) data).getString().equals("x5c")) {

--- a/src/main/webapp/js/webauthn.js
+++ b/src/main/webapp/js/webauthn.js
@@ -122,15 +122,15 @@ function addCredential() {
     makeCredentialOptions.rp = options.rp;
     makeCredentialOptions.user = options.user;
     makeCredentialOptions.challenge = Uint8Array.from(atob(options.challenge), c => c.charCodeAt(0));
-    
+
     makeCredentialOptions.parameters = options.parameters;
     if ('timeout' in options) {
-      makeCredentialOptions.timeout = options.timeout; 
+      makeCredentialOptions.timeout = options.timeout;
     }
     if ('excludeList' in options) {
       makeCredentialOptions.excludeList = credentialListConversion(parameters.excludeList);
     }
-    
+
     var createParams = {};
     createParams.publicKey = makeCredentialOptions;
 
@@ -159,7 +159,7 @@ function addCredential() {
       }
       if ('response' in attestation) {
         var response = {};
-        response.clientDataJSON = attestation.response.clientDataJSON;
+        response.clientDataJSON = new Uint8Array(attestation.response.clientDataJSON);
         response.attestationObject = btoa(
           new Uint8Array(attestation.response.attestationObject)
           .reduce((s, byte) => s + String.fromCharCode(byte), ''));
@@ -220,7 +220,7 @@ function getAssertion() {
     if ('allowList' in parameters) {
       requestOptions.allowList = credentialListConversion(parameters.allowList);
     }
-    
+
     var credentialRequest = {};
     credentialRequest.publicKey = requestOptions;
     console.log(credentialRequest);
@@ -238,7 +238,7 @@ function getAssertion() {
         publicKeyCredential.id = assertion.id;
       }
       if ('type' in assertion) {
-        publicKeyCredential.type = assertion.type;        
+        publicKeyCredential.type = assertion.type;
       }
       if ('rawId' in assertion) {
         publicKeyCredential.rawId = btoa(


### PR DESCRIPTION
Allow successful registration.
Properly wrap the clientDataJSON object before posting.
Add handling to clientDataJSON to maintain order
of the values for hashing and verification.