### PR TITLE
Detect use of the same authenticator on a per user

### DIFF
--- a/src/main/java/com/google/webauthn/gaedemo/exceptions/DuplicateAuthenticatorException.java
+++ b/src/main/java/com/google/webauthn/gaedemo/exceptions/DuplicateAuthenticatorException.java
@@ -1,0 +1,37 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.webauthn.gaedemo.exceptions;
+
+public class DuplicateAuthenticatorException extends Exception {
+
+  private final byte[] rawId;
+
+  /**
+   * @param string
+   * @param rawId
+   */
+  public DuplicateAuthenticatorException(String string, byte[] rawId) {
+    super(string);
+    this.rawId = rawId;
+  }
+
+  /**
+   * @return Duplicated authenticator rawId
+   */
+  public byte[] getRawId() {
+    return rawId;
+  }
+
+}

--- a/src/main/java/com/google/webauthn/gaedemo/objects/AndroidSafetyNetAttestationStatement.java
+++ b/src/main/java/com/google/webauthn/gaedemo/objects/AndroidSafetyNetAttestationStatement.java
@@ -105,4 +105,14 @@ public class AndroidSafetyNetAttestationStatement extends AttestationStatement {
   public String getName() {
     return "Android SafetyNet";
   }
+
+  @Override
+  public AttestationStatementEnum getAttestationType() {
+    return AttestationStatementEnum.ANDROIDSAFETYNET;
+  }
+
+  @Override
+  public byte[] getCert() {
+    return response;
+  }
 }

--- a/src/main/java/com/google/webauthn/gaedemo/objects/AttestationStatement.java
+++ b/src/main/java/com/google/webauthn/gaedemo/objects/AttestationStatement.java
@@ -26,24 +26,24 @@ public abstract class AttestationStatement {
    * @return Attestation statement of provided format
    */
   public static AttestationStatement decode(String fmt, DataItem attStmt) {
-    if (fmt.equals("fido-u2f")) {
-      FidoU2fAttestationStatement stmt = FidoU2fAttestationStatement.decode(attStmt);
-      return stmt;
-    } else if (fmt.equals("android-safetynet")) {
-      AndroidSafetyNetAttestationStatement stmt;
-      try {
-        stmt = AndroidSafetyNetAttestationStatement.decode(attStmt);
-      } catch (ResponseException e) {
+    switch (AttestationStatementEnum.decode(fmt)) {
+      case FIDOU2F:
+        return FidoU2fAttestationStatement.decode(attStmt);
+      case ANDROIDSAFETYNET:
+        AndroidSafetyNetAttestationStatement stmt;
+        try {
+          stmt = AndroidSafetyNetAttestationStatement.decode(attStmt);
+        } catch (ResponseException e) {
+          return null;
+        }
+        return stmt;
+      case PACKED:
+        return PackedAttestationStatement.decode(attStmt);
+      case NONE:
+        return new NoneAttestationStatement();
+      default:
         return null;
-      }
-      return stmt;
-    } else if (fmt.equals("packed")) {
-      return PackedAttestationStatement.decode(attStmt);
-    } else if (fmt.equals("none")) {
-      return new NoneAttestationStatement();
     }
-
-    return null;
   }
 
   /**
@@ -54,5 +54,8 @@ public abstract class AttestationStatement {
 
   public abstract String getName();
 
+  public abstract AttestationStatementEnum getAttestationType();
+
+  public abstract byte[] getCert();
 
 }

--- a/src/main/java/com/google/webauthn/gaedemo/objects/AttestationStatementEnum.java
+++ b/src/main/java/com/google/webauthn/gaedemo/objects/AttestationStatementEnum.java
@@ -15,5 +15,35 @@
 package com.google.webauthn.gaedemo.objects;
 
 public enum AttestationStatementEnum {
-  FIDOU2F, ANDROIDSAFETYNET, PACKED, NONE;
+  FIDOU2F("fido-u2f"),
+  ANDROIDSAFETYNET("android-safetynet"),
+  PACKED("packed"),
+  NONE("none");
+
+  private final String name;
+
+  /**
+   * @param name
+   */
+  private AttestationStatementEnum(String name) {
+    this.name = name;
+  }
+
+  /**
+   * @param s
+   * @return Attestation Statement Format Identifiers corresponding to the input string
+   */
+  public static AttestationStatementEnum decode(String s) {
+    for (AttestationStatementEnum t : AttestationStatementEnum.values()) {
+      if (t.name.equals(s)) {
+        return t;
+      }
+    }
+    throw new IllegalArgumentException(s + " not a valid Attestation Statement Format Identifiers");
+  }
+
+  @Override
+  public String toString() {
+    return name;
+  }
 }

--- a/src/main/java/com/google/webauthn/gaedemo/objects/FidoU2fAttestationStatement.java
+++ b/src/main/java/com/google/webauthn/gaedemo/objects/FidoU2fAttestationStatement.java
@@ -126,4 +126,14 @@ public class FidoU2fAttestationStatement extends AttestationStatement {
   public String getName() {
     return "FIDO U2F Authenticator";
   }
+
+  @Override
+  public AttestationStatementEnum getAttestationType() {
+    return AttestationStatementEnum.FIDOU2F;
+  }
+
+  @Override
+  public byte[] getCert() {
+    return attestnCert;
+  }
 }

--- a/src/main/java/com/google/webauthn/gaedemo/objects/NoneAttestationStatement.java
+++ b/src/main/java/com/google/webauthn/gaedemo/objects/NoneAttestationStatement.java
@@ -14,7 +14,6 @@
 
 package com.google.webauthn.gaedemo.objects;
 
-import co.nstant.in.cbor.CborDecoder;
 import co.nstant.in.cbor.CborException;
 import co.nstant.in.cbor.model.DataItem;
 import co.nstant.in.cbor.model.Map;
@@ -41,5 +40,15 @@ public class NoneAttestationStatement extends AttestationStatement {
   @Override
   public String getName() {
     return "NONE ATTESTATION";
+  }
+
+  @Override
+  public AttestationStatementEnum getAttestationType() {
+    return AttestationStatementEnum.NONE;
+  }
+
+  @Override
+  public byte[] getCert() {
+    return null;
   }
 }

--- a/src/main/java/com/google/webauthn/gaedemo/objects/PackedAttestationStatement.java
+++ b/src/main/java/com/google/webauthn/gaedemo/objects/PackedAttestationStatement.java
@@ -169,4 +169,14 @@ public class PackedAttestationStatement extends AttestationStatement {
   public String getName() {
     return "Packed Attestation";
   }
+
+  @Override
+  public AttestationStatementEnum getAttestationType() {
+    return AttestationStatementEnum.PACKED;
+  }
+
+  @Override
+  public byte[] getCert() {
+    return attestnCert;
+  }
 }

--- a/src/main/java/com/google/webauthn/gaedemo/objects/PublicKeyCredential.java
+++ b/src/main/java/com/google/webauthn/gaedemo/objects/PublicKeyCredential.java
@@ -65,19 +65,10 @@ public class PublicKeyCredential {
     try {
       AuthenticatorAttestationResponse attRsp = (AuthenticatorAttestationResponse) response;
       AttestationStatement attStmt = attRsp.decodedObject.getAttestationStatement();
-      if (attStmt instanceof AndroidSafetyNetAttestationStatement) {
-        return AttestationStatementEnum.ANDROIDSAFETYNET;
-      } else if (attStmt instanceof FidoU2fAttestationStatement) {
-        return AttestationStatementEnum.FIDOU2F;
-      } else if (attStmt instanceof PackedAttestationStatement) {
-        return AttestationStatementEnum.PACKED;
-      } else if (attStmt instanceof NoneAttestationStatement) {
-        return AttestationStatementEnum.NONE;
-      }
+      return attStmt.getAttestationType();
     } catch (ClassCastException e) {
       return null;
     }
-    return null;
   }
 
   /**

--- a/src/main/java/com/google/webauthn/gaedemo/server/PackedServer.java
+++ b/src/main/java/com/google/webauthn/gaedemo/server/PackedServer.java
@@ -21,7 +21,6 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
-import java.util.List;
 import java.util.logging.Logger;
 
 import javax.servlet.ServletException;
@@ -29,6 +28,7 @@ import javax.servlet.ServletException;
 import com.google.common.primitives.Bytes;
 import com.google.webauthn.gaedemo.crypto.AlgorithmIdentifierMapper;
 import com.google.webauthn.gaedemo.crypto.Crypto;
+import com.google.webauthn.gaedemo.exceptions.DuplicateAuthenticatorException;
 import com.google.webauthn.gaedemo.exceptions.ResponseException;
 import com.google.webauthn.gaedemo.exceptions.WebAuthnException;
 import com.google.webauthn.gaedemo.objects.AuthenticatorAssertionResponse;
@@ -91,20 +91,13 @@ public class PackedServer extends Server {
    * @throws ServletException
    */
   public static void registerCredential(PublicKeyCredential cred, String currentUser,
-      String session, String origin) throws ServletException {
+      String session, String origin) throws ServletException, DuplicateAuthenticatorException {
 
-    if (!(cred.getResponse() instanceof AuthenticatorAttestationResponse)) {
-      throw new ServletException("Invalid response structure");
-    }
-
-    AuthenticatorAttestationResponse attResponse =
-        (AuthenticatorAttestationResponse) cred.getResponse();
-
-    List<Credential> savedCreds = Credential.load(currentUser);
-    for (Credential c : savedCreds) {
-      if (c.getCredential().id.equals(cred.id)) {
-        throw new ServletException("Credential already registerd for this user");
-      }
+    AuthenticatorAttestationResponse attResponse;
+    try {
+      attResponse = verifyAttestationResponse(cred, currentUser);
+    } catch (ResponseException e) {
+      throw new ServletException(e.getMessage());
     }
 
     try {

--- a/src/main/webapp/js/webauthn.js
+++ b/src/main/webapp/js/webauthn.js
@@ -35,6 +35,17 @@ const onClick = (q, func) => {
   $(q).addEventListener('click', func);
 };
 
+const easing = (id, color) => {
+  document.getElementById(id).animate([{
+    backgroundColor: color
+  },{
+    backgroundColor: 'white'
+  }], {
+    duration: 2000,
+    easing: 'ease-out'
+  });
+};
+
 function addErrorMsg(msg) {
   $('#error-text').innerHTML = msg;
   show('#error');
@@ -48,6 +59,14 @@ function addSuccessMsg(msg) {
 function removeMsgs() {
   hide('#error');
   hide('#success');
+};
+
+function highlightSuccessCard(cardId) {
+  easing(cardId, '#009688')
+};
+
+function highlightErrorCard(cardId) {
+  easing(cardId, '#F44336')
 };
 
 function _fetch(url, obj) {
@@ -230,12 +249,19 @@ function addCredential() {
       session: _options.session.id
     });
 
-  }).then(parameters => {
-    console.log(parameters);
+  }).then(result => {
+    console.log(result);
 
-    if (parameters && parameters.success) {
-      addSuccessMsg(parameters.message);
-      fetchCredentials();
+    if (result) {
+      if (result.success) {
+        addSuccessMsg(result.message);
+        fetchCredentials();
+      } else if ('handle' in result) {
+        addErrorMsg(result.message);
+        highlightErrorCard(result.handle);
+      } else {
+        addErrorMsg(result.message);
+      }
     } else {
       throw 'Unexpected response received.';
     }
@@ -313,15 +339,7 @@ function getAssertion() {
     if (result && result.success) {
       addSuccessMsg(result.message);
       if ('handle' in result) {
-        let card = document.getElementById(result.handle);
-        card.animate([{
-          backgroundColor: '#009688'
-        },{
-          backgroundColor: 'white'
-        }], {
-          duration: 2000,
-          easing: 'ease-out'
-        });
+        highlightSuccessCard(result.handle);
       }
     }
   }).catch(err => {


### PR DESCRIPTION
I implemented to detect duplicate registration of authenticator on a user basis when AttestationConveyancePreference is set and attestation statements are sent.

![detect_converyance_pref_direct](https://user-images.githubusercontent.com/10364603/39092890-a3ee94b6-4651-11e8-93df-a5580a0f4f27.gif)
