### PR TITLE
Update assetlinks.json in preparation for assetlinking changes

### DIFF
--- a/src/main/webapp/well-known/assetlinks.json
+++ b/src/main/webapp/well-known/assetlinks.json
@@ -1,12 +1,12 @@
 [{
-  "relation": ["delegate_permission/common.handle_all_urls"],
+  "relation": ["delegate_permission/common.handle_all_urls", "delegate_permission/common.get_login_creds"],
   "target": {
     "namespace": "web",
     "site": "https://webauthndemo.appspot.com"
   }
 },
 {
-  "relation": ["delegate_permission/common.handle_all_urls"],
+  "relation": ["delegate_permission/common.handle_all_urls", "delegate_permission/common.get_login_creds"],
   "target": {
     "namespace": "android_app",
     "package_name": "com.fido.example.fido2apiexample",
@@ -17,7 +17,7 @@
   }
 },
 {
-  "relation": ["delegate_permission/common.handle_all_urls"],
+  "relation": ["delegate_permission/common.handle_all_urls", "delegate_permission/common.get_login_creds"],
   "target": {
     "namespace": "android_app",
     "package_name": "com.fido.example.zeropartyexample",


### PR DESCRIPTION
Update assetlinks.json in preparation for assetlinking requiring delegate_permission/common.get_login_creds. Once we roll the change out to 100%, I'll remove the common.handle_all_urls.