### PR TITLE
Align with Android FIDO2 sample app's new keystore

### DIFF
--- a/src/main/java/com/google/webauthn/gaedemo/endpoints/Constants.java
+++ b/src/main/java/com/google/webauthn/gaedemo/endpoints/Constants.java
@@ -15,7 +15,7 @@ public class Constants {
   public static final String WEB_CLIENT_ID =
       "762961289381-hbbpkaqgi1kelev5mquj4dg4n8glr59p.apps.googleusercontent.com";
   public static final String ANDROID_CLIENT_ID =
-      "762961289381-d27cfmh1st5m681lo2r7837hg0a6b0pm.apps.googleusercontent.com";
+      "762961289381-87bpacb39s1pi3tsi2ahlsqvsmuh3odr.apps.googleusercontent.com";
   public static final String ANDROID_AUDIENCE = WEB_CLIENT_ID;
 
   public static final String APP_ID = "webauthndemo.appspot.com";

--- a/src/main/java/com/google/webauthn/gaedemo/endpoints/Constants.java
+++ b/src/main/java/com/google/webauthn/gaedemo/endpoints/Constants.java
@@ -15,6 +15,8 @@ public class Constants {
   public static final String WEB_CLIENT_ID =
       "762961289381-hbbpkaqgi1kelev5mquj4dg4n8glr59p.apps.googleusercontent.com";
   public static final String ANDROID_CLIENT_ID =
+      "762961289381-d27cfmh1st5m681lo2r7837hg0a6b0pm.apps.googleusercontent.com";
+  public static final String ANDROID_CLIENT_ID2 =
       "762961289381-87bpacb39s1pi3tsi2ahlsqvsmuh3odr.apps.googleusercontent.com";
   public static final String ANDROID_AUDIENCE = WEB_CLIENT_ID;
 

--- a/src/main/java/com/google/webauthn/gaedemo/endpoints/Fido2RequestHandler.java
+++ b/src/main/java/com/google/webauthn/gaedemo/endpoints/Fido2RequestHandler.java
@@ -44,7 +44,8 @@ import com.google.webauthn.gaedemo.storage.SessionData;
   name = "fido2RequestHandler",
   version = "v1",
   scopes = {Constants.EMAIL_SCOPE, Constants.OPENID_SCOPE},
-  clientIds = {Constants.WEB_CLIENT_ID, Constants.ANDROID_CLIENT_ID},
+  clientIds = {Constants.WEB_CLIENT_ID, Constants.ANDROID_CLIENT_ID,
+      Constants.ANDROID_CLIENT_ID2},
   audiences = {Constants.ANDROID_AUDIENCE},
   namespace = @ApiNamespace(
       ownerName = "gaedemo.webauthn.google.com", ownerDomain = "gaedemo.webauthn.google.com")

--- a/src/main/webapp/well-known/assetlinks.json
+++ b/src/main/webapp/well-known/assetlinks.json
@@ -12,7 +12,7 @@
     "package_name": "com.fido.example.fido2apiexample",
     "sha256_cert_fingerprints": [
       "83:1E:EC:AB:FA:71:87:18:6B:21:07:4B:C9:F1:B4:A7:12:B0:88:9E:E1:3A:4D:83:25:0E:31:BC:A7:78:DF:C4",
-      "6E:41:E7:95:61:15:FE:34:42:3D:D6:06:25:FC:0E:97:B4:A7:FC:22:C2:FF:64:C4:DE:1E:13:3B:5F:E7:DF:82"
+      "90:61:22:59:30:58:E4:3F:18:13:5C:07:BB:DC:43:F7:06:46:4E:CC:8C:C3:23:61:19:A9:9D:DF:82:13:DC:D7"
     ]
   }
 },


### PR DESCRIPTION
* Replace the client id at ANDROID_CLIENT_ID with a new one.
* Add a new SHA256 hash to assetlinks.json.