### PR TITLE
Add AbortTimeout for webauthn demo

### DIFF
--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -94,6 +94,13 @@
           </div>
         </div>
         <div class="mdl-list__item">
+          <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+            <input class="mdl-textfield__input" type="text" pattern="-?[0-9]*(\.[0-9]+)?" id="abortTimeout">
+            <label class="mdl-textfield__label" for="abortTimeout">AbortTimeout (milliseconds)</label>
+            <span class="mdl-textfield__error">Input is not a number!</span>
+          </div>
+        </div>
+        <div class="mdl-list__item">
           <a href="${logoutUrl}">Logout</a>
         </div>
       </div>

--- a/src/main/webapp/js/webauthn.js
+++ b/src/main/webapp/js/webauthn.js
@@ -308,13 +308,26 @@ function makeCredential(advancedOptions) {
     }
 
     console.log(makeCredentialOptions);
-
+  
+    if ($('#abortTimeout').value != '') {
+      authAbortController = new AbortController();
+      authAbortSignal = authAbortController.signal;
+      setTimeout(function(){ authAbortController.abort(); }, $('#abortTimeout').value);
+      return navigator.credentials.create({
+        "publicKey": makeCredentialOptions,
+        "signal": authAbortSignal
+      });
+    }
     return navigator.credentials.create({
       "publicKey": makeCredentialOptions
     });
 
   }).then(attestation => {
     hide('#active');
+
+    if ($('#abortTimeout').value != '') {
+      clearTimeout();
+    }
 
     const publicKeyCredential = {};
 
@@ -411,12 +424,26 @@ function getAssertion() {
 
     console.log(requestOptions);
 
+    if ($('#abortTimeout').value != '') {
+      authAbortController = new AbortController();
+      authAbortSignal = authAbortController.signal;
+      setTimeout(function(){ authAbortController.abort(); }, $('#abortTimeout').value);
+      return navigator.credentials.get({
+        "publicKey": requestOptions,
+        "signal": authAbortSignal
+      });
+    }
+
     return navigator.credentials.get({
       "publicKey": requestOptions
     });
 
   }).then(assertion => {
     hide('#active');
+  
+    if ($('#abortTimeout').value != '') {
+      clearTimeout();
+    }
 
     const publicKeyCredential = {};
 


### PR DESCRIPTION
WebauthN API now support abort operation for user to cancel the ongoing
request. It is appropriate to add this in demo to test it manually.