### PR TITLE
Adding support for RsaKey for self-attestation

### DIFF
--- a/src/main/java/com/google/webauthn/gaedemo/server/PackedServer.java
+++ b/src/main/java/com/google/webauthn/gaedemo/server/PackedServer.java
@@ -175,6 +175,10 @@ public class PackedServer extends Server {
             .getPublicKey() instanceof EccKey) {
           publicKey = Crypto.getECPublicKey((EccKey) attResponse.decodedObject
               .getAuthenticatorData().getAttData().getPublicKey());
+        } else if (attResponse.decodedObject.getAuthenticatorData().getAttData()
+                .getPublicKey() instanceof RsaKey){
+          publicKey = Crypto.getRSAPublicKey((RsaKey) attResponse.decodedObject
+                  .getAuthenticatorData().getAttData().getPublicKey());
         } else {
           throw new ServletException("Public Key not supported");
         }


### PR DESCRIPTION
- While testing in production, we found that windows devices with Hello support are generating self-attestation format with Rsa crypto and the current code is not supporting that
- Raising this PR to expand the coverage and prevent failures