### PR TITLE
Update main.ts DOM text reinterpreted as HTML

### DIFF
--- a/src/public/scripts/main.ts
+++ b/src/public/scripts/main.ts
@@ -106,10 +106,10 @@ const onSignout = async (e: any) => {
   $('#user-info').close();
   await auth.signOut();
   await _fetch('/auth/signout');
-  icon.innerHTML = '';
+  icon.innerText = '';
   icon.setAttribute('icon', 'account_circle');
   $('#drawer').open = false;
-  $('#credentials').innerHTML = '';
+  $('#credentials').innerText = '';
   showSnackbar('You are signed out.');
   displaySignin();
 };


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML. 